### PR TITLE
lastlog2: Fix header alignment

### DIFF
--- a/src/lastlog2.c
+++ b/src/lastlog2.c
@@ -78,10 +78,10 @@ print_entry (const char *user, time_t ll_time,
 
   if (!once)
     {
-      printf ("Username         Port     From%*sLatest\n", maxIPv6Addrlen-3, " ");
+      printf ("Username         Port     From%*s Latest\n", maxIPv6Addrlen-4, " ");
       once = 1;
     }
-  printf ("%-16s %-8.8s %*s%s\n", user, tty ? tty : "",
+  printf ("%-16s %-8.8s %*s %s\n", user, tty ? tty : "",
 	  -maxIPv6Addrlen, rhost ? rhost : "", datep);
 
   return 0;


### PR DESCRIPTION
The "From" header is four characters long, substract that. Also add an additional space to delimit even long IPv6 addresses from the date.

Before:

```
linux@localhost:~> lastlog2 
Username         Port     From                                       Latest
linux            :0                                                 Tue Apr  4 08:44:44 -0400 2023
```

After:

```
linux@localhost:~> lastlog2 
Username         Port     From                                       Latest
linux            ssh      192.168.100.1                              Tue Apr  4 08:50:48 -0400 2023
```