### PR TITLE
remove lto to fix link error of clang

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,6 @@ add_project_arguments(['-D_GNU_SOURCE=1',
                        '-DPROJECT_VERSION="@0@"'.format(meson.project_version()) ], language : 'c')
 
 possible_cc_flags = [
-                  '-flto=auto',
                   '-ffat-lto-objects',
 		  '-fstack-protector-strong',
 		  '-funwind-tables',


### PR DESCRIPTION
error message:
liblastlog2.so.1.p/lib_lastlog2.c.o: file not recognized: file format not recognized