### PR TITLE
show_lastlogin: Don't read if no database

### DIFF
--- a/include/lastlog2.h
+++ b/include/lastlog2.h
@@ -31,6 +31,9 @@
 
 #include <stdint.h>
 
+/* Check if database file exists.
+   Returns 0 on success, -1 on failure. */
+extern int ll2_check_database (const char *lastlog2_path);
 /* Write a new entry. Returns 0 on success, -1 on failure. */
 extern int ll2_write_entry (const char *lastlog2_path, const char *user,
 			    int64_t ll_time, const char *tty,

--- a/lib/lastlog2.c
+++ b/lib/lastlog2.c
@@ -75,6 +75,14 @@ open_database_rw (const char *path, char **error)
   return db;
 }
 
+/* Check if database file exists.
+   Returns 0 on success, -1 on failure. */
+int ll2_check_database (const char *lastlog2_path)
+{
+    struct stat st;
+    return stat(lastlog2_path, &st);
+}
+
 /* Reads one entry from database and returns that.
    Returns 0 on success, -1 on failure. */
 static int

--- a/lib/liblastlog2.map
+++ b/lib/liblastlog2.map
@@ -9,3 +9,8 @@ LIBLASTLOG2_1.0 {
         ll2_import_lastlog;
   local: *;
 };
+
+LIBLASTLOG2_1.2 {
+  global:
+        ll2_check_database;
+} LIBLASTLOG2_1.0;

--- a/src/pam_lastlog2.c
+++ b/src/pam_lastlog2.c
@@ -239,7 +239,10 @@ show_lastlogin (pam_handle_t *pamh, int ctrl, const char *user)
   int retval = PAM_SUCCESS;
 
   if (ctrl & LASTLOG2_QUIET)
-    return PAM_SUCCESS;
+    return retval;
+
+  if (ll2_check_database (lastlog2_path) != 0)
+    return retval;
 
   if (ll2_read_entry (lastlog2_path, user, &ll_time, &tty, &rhost,
 		      &service, &error) != 0)

--- a/tests/tst-pam_lastlog2-output.c
+++ b/tests/tst-pam_lastlog2-output.c
@@ -66,6 +66,12 @@ main(void)
       return 1;
     }
 
+  if (ll2_check_database (db_path) != 0)
+    {
+      fprintf(stderr, "ll2_check_database failed");
+      return 1;
+    }
+
   if (ll2_read_entry (db_path, user, &ll_time, &tty, &rhost,
 		      NULL, &error) != 0)
     {


### PR DESCRIPTION
  * At first login on the system, show_lastlogin logged an unwanted error message. As no login has been proceed before, no database has been yet created, and ll2_read_entry() will try to open a non-existing file. Check before reading if the database has been creating.
  * Add new lib function ll2_check_database().
  * Add tests.