### PR TITLE
lastlog: make output closer to original lastlog

### DIFF
--- a/lib/lastlog2.c
+++ b/lib/lastlog2.c
@@ -84,7 +84,7 @@ int ll2_check_database (const char *lastlog2_path)
 }
 
 /* Reads one entry from database and returns that.
-   Returns 0 on success, -1 on failure. */
+   Returns 0 on success, -1 on failure, -2 on user not found. */
 static int
 read_entry (sqlite3 *db, const char *user,
 	    int64_t *ll_time, char **tty, char **rhost,
@@ -160,7 +160,7 @@ read_entry (sqlite3 *db, const char *user,
 	if (asprintf (error, "User '%s' not found (%d)", user, step) < 0)
 	  *error = strdup("Out of memory");
 
-      retval = -1;
+      retval = -2;
     }
 
   sqlite3_finalize (res);
@@ -168,7 +168,8 @@ read_entry (sqlite3 *db, const char *user,
   return retval;
 }
 
-/* reads 1 entry from database and returns that. Returns 0 on success, -1 on failure. */
+/* reads 1 entry from database and returns that.
+   Returns 0 on success, -1 on failure, -2 on user not found. */
 int
 ll2_read_entry (const char *lastlog2_path, const char *user,
 		int64_t *ll_time, char **tty, char **rhost,


### PR DESCRIPTION
Some programs, like cockpit, depend on lastlog printing data in a certain way. By default lastlog prints all users in the order that they are found in /etc/shadow and doesn't print extra space after Latest column if Service column is not printed.

Replicate the old lastlog behavior by going through all the users in the password database and checking if user is found from the lastlog database.